### PR TITLE
feat: Case-insensitive biome id and fix Core reference

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -1,20 +1,14 @@
 {
-  "id": "CoreWorlds",
-  "version": "1.1.0",
-  "isReleaseManaged": true,
-  "author": "The Terasology Foundation",
-  "displayName": "CoreWorlds",
-  "description": "A basic set of world generators and facets.",
-  "dependencies": [
-    {
-      "id": "BiomesAPI",
-      "minVersion": "4.0.0"
-    },
-    {
-      "id": "CoreAssets",
-      "minVersion": "2.0.0"
-    }
-  ],
-  "serverSideOnly": false,
-  "isWorld": true
+    "id": "CoreWorlds",
+    "version": "1.1.0",
+    "isReleaseManaged": true,
+    "author": "The Terasology Foundation",
+    "displayName": "CoreWorlds",
+    "description": "A basic set of world generators and facets.",
+    "dependencies": [
+        { "id": "BiomesAPI", "minVersion": "4.0.0" },
+        { "id": "CoreAssets", "minVersion": "2.0.1" }
+    ],
+    "serverSideOnly": false,
+    "isWorld": true
 }

--- a/module.txt
+++ b/module.txt
@@ -1,6 +1,6 @@
 {
   "id": "CoreWorlds",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "isReleaseManaged": true,
   "author": "The Terasology Foundation",
   "displayName": "CoreWorlds",
@@ -8,7 +8,7 @@
   "dependencies": [
     {
       "id": "BiomesAPI",
-      "minVersion": "3.0.0"
+      "minVersion": "4.0.0"
     },
     {
       "id": "CoreAssets",

--- a/src/main/java/org/terasology/core/world/CoreBiome.java
+++ b/src/main/java/org/terasology/core/world/CoreBiome.java
@@ -16,6 +16,7 @@
 package org.terasology.core.world;
 
 import org.terasology.biomesAPI.Biome;
+import org.terasology.naming.Name;
 
 public enum CoreBiome implements Biome {
     MOUNTAINS("Mountains"),
@@ -26,27 +27,27 @@ public enum CoreBiome implements Biome {
     BEACH("Beach"),
     PLAINS("Plains");
 
-    private final String id;
-    private final String name;
+    private final Name id;
+    private final String displayName;
 
-    CoreBiome(String name) {
-        this.id = "Core:" + name().toLowerCase();
-        this.name = name;
+    CoreBiome(String displayName) {
+        this.id = new Name("CoreWorlds:" + name());
+        this.displayName = displayName;
     }
 
     @Override
-    public String getId() {
+    public Name getId() {
         return id;
     }
 
     @Override
-    public String getName() {
-        return this.name;
+    public String getDisplayName() {
+        return this.displayName;
     }
 
     @Override
     public String toString() {
-        return this.name;
+        return this.displayName;
     }
 
 }


### PR DESCRIPTION
There was a missed reference to `Core:` in the biome definition. To safeguard against case-sensitivity issues this depends on Terasology/BiomesAPI#1