### PR TITLE
chore: remove SurfaceHeightFacet entirely

### DIFF
--- a/src/main/java/org/terasology/core/world/generator/facetProviders/PositionFilters.java
+++ b/src/main/java/org/terasology/core/world/generator/facetProviders/PositionFilters.java
@@ -19,9 +19,8 @@ package org.terasology.core.world.generator.facetProviders;
 import com.google.common.base.Predicate;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.utilities.procedural.Noise;
-import org.terasology.world.generation.facets.SurfacesFacet;
 import org.terasology.world.generation.facets.DensityFacet;
-import org.terasology.world.generation.facets.SurfaceHeightFacet;
+import org.terasology.world.generation.facets.SurfacesFacet;
 
 import java.util.Set;
 
@@ -123,52 +122,6 @@ public final class PositionFilters {
                     }
                 }
                 return false;
-            }
-        };
-    }
-
-    /**
-     * Filters based on surface flatness using the deprecated SurfaceHeightFacet
-     *
-     * @param surfaceFacet the surface height facet that contains all tested coords.
-     * @return a predicate that returns true only if there is a level surface in adjacent directions
-     */
-    public static Predicate<Vector3i> flatness(final SurfaceHeightFacet surfaceFacet) {
-        return flatness(surfaceFacet, 0, 0);
-    }
-
-    /**
-     * Filters based on surface flatness using the deprecated SurfaceHeightFacet
-     *
-     * @param surfaceFacet the surface height facet that contains all tested coords.
-     * @param divUp        surface can be higher up to <code>divUp</code>.
-     * @param divDown      surface can be lower up to <code>divDown</code>.
-     * @return a predicate that returns true only if there is a level surface in adjacent directions
-     */
-    public static Predicate<Vector3i> flatness(final SurfaceHeightFacet surfaceFacet, final int divUp, final int divDown) {
-
-        return new Predicate<Vector3i>() {
-
-            @Override
-            public boolean apply(Vector3i input) {
-                int x = input.getX();
-                int z = input.getZ();
-                int level = input.getY() - 1;
-                int min = level - divDown;
-                int max = level + divUp;
-
-                return inBounds(blockHeightAt(x - 1, z), min, max)
-                        && inBounds(blockHeightAt(x + 1, z), min, max)
-                        && inBounds(blockHeightAt(x, z - 1), min, max)
-                        && inBounds(blockHeightAt(x, z + 1), min, max);
-            }
-
-            private boolean inBounds(int height, int min, int max) {
-                return height >= min && height <= max;
-            }
-
-            private int blockHeightAt(int x, int z) {
-                return (int) Math.floor(surfaceFacet.getWorld(x, z));
             }
         };
     }

--- a/src/main/java/org/terasology/core/world/generator/facetProviders/SurfaceObjectProvider.java
+++ b/src/main/java/org/terasology/core/world/generator/facetProviders/SurfaceObjectProvider.java
@@ -21,13 +21,11 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
 import org.terasology.math.Region3i;
-import org.terasology.math.TeraMath;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.utilities.procedural.Noise;
 import org.terasology.utilities.procedural.WhiteNoise;
 import org.terasology.world.generation.FacetProvider;
 import org.terasology.world.generation.facets.SurfacesFacet;
-import org.terasology.world.generation.facets.SurfaceHeightFacet;
 import org.terasology.world.generation.facets.base.ObjectFacet2D;
 import org.terasology.world.generation.facets.base.ObjectFacet3D;
 
@@ -85,46 +83,6 @@ public abstract class SurfaceObjectProvider<B, T> implements FacetProvider {
                             if (type != null) {
                                 facet.setWorld(x, height, z, type);
                             }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * Populates a given facet based on filters and population densities using the deprecated SurfaceHeightFacet
-     *
-     * @param facet        the facet to populate
-     * @param surfaceFacet the surface height facet
-     * @param typeFacet    the facet that provides the environment
-     * @param filters      a set of filters
-     */
-    protected void populateFacet(ObjectFacet3D<T> facet, SurfaceHeightFacet surfaceFacet, ObjectFacet2D<? extends B> typeFacet, List<Predicate<Vector3i>> filters) {
-
-        Region3i worldRegion = facet.getWorldRegion();
-
-        int minY = worldRegion.minY();
-        int maxY = worldRegion.maxY();
-
-        Vector3i pos = new Vector3i();
-
-        for (int z = worldRegion.minZ(); z <= worldRegion.maxZ(); z++) {
-            for (int x = worldRegion.minX(); x <= worldRegion.maxX(); x++) {
-                int height = TeraMath.floorToInt(surfaceFacet.getWorld(x, z)) + 1;
-
-                // if the surface is in range
-                if (height >= minY && height <= maxY) {
-
-                    pos.set(x, height, z);
-
-                    // if all predicates match
-                    if (applyAll(filters, pos)) {
-                        B biome = typeFacet.getWorld(x, z);
-                        Map<T, Float> plantProb = probsTable.row(biome);
-                        T type = getType(x, z, plantProb);
-                        if (type != null) {
-                            facet.setWorld(x, height, z, type);
                         }
                     }
                 }

--- a/src/main/java/org/terasology/core/world/generator/worldGenerators/FlatWorldGenerator.java
+++ b/src/main/java/org/terasology/core/world/generator/worldGenerators/FlatWorldGenerator.java
@@ -29,7 +29,6 @@ import org.terasology.core.world.generator.rasterizers.TreeRasterizer;
 import org.terasology.engine.SimpleUri;
 import org.terasology.registry.In;
 import org.terasology.world.generation.BaseFacetedWorldGenerator;
-import org.terasology.world.generation.SurfaceHeightCompatibilityProvider;
 import org.terasology.world.generation.WorldBuilder;
 import org.terasology.world.generator.RegisterWorldGenerator;
 import org.terasology.world.generator.plugin.WorldGeneratorPluginLibrary;
@@ -56,7 +55,6 @@ public class FlatWorldGenerator extends BaseFacetedWorldGenerator {
                 .addProvider(new SurfaceToDensityProvider())
                 .addProvider(new DefaultFloraProvider())
                 .addProvider(new DefaultTreeProvider())
-                .addProvider(new SurfaceHeightCompatibilityProvider())
                 .addRasterizer(new FloraRasterizer())
                 .addRasterizer(new TreeRasterizer())
                 .addRasterizer(new SolidRasterizer())

--- a/src/main/java/org/terasology/core/world/generator/worldGenerators/HeightMapWorldGenerator.java
+++ b/src/main/java/org/terasology/core/world/generator/worldGenerators/HeightMapWorldGenerator.java
@@ -29,7 +29,6 @@ import org.terasology.core.world.generator.rasterizers.TreeRasterizer;
 import org.terasology.engine.SimpleUri;
 import org.terasology.registry.In;
 import org.terasology.world.generation.BaseFacetedWorldGenerator;
-import org.terasology.world.generation.SurfaceHeightCompatibilityProvider;
 import org.terasology.world.generation.WorldBuilder;
 import org.terasology.world.generator.RegisterWorldGenerator;
 import org.terasology.world.generator.plugin.WorldGeneratorPluginLibrary;
@@ -58,7 +57,6 @@ public class HeightMapWorldGenerator extends BaseFacetedWorldGenerator {
                 .addProvider(new SurfaceToDensityProvider())
                 .addProvider(new DefaultFloraProvider())
                 .addProvider(new DefaultTreeProvider())
-                .addProvider(new SurfaceHeightCompatibilityProvider())
                 .addRasterizer(new FloraRasterizer())
                 .addRasterizer(new TreeRasterizer())
                 .addRasterizer(new SolidRasterizer())

--- a/src/main/java/org/terasology/core/world/generator/worldGenerators/PerlinFacetedWorldGenerator.java
+++ b/src/main/java/org/terasology/core/world/generator/worldGenerators/PerlinFacetedWorldGenerator.java
@@ -18,13 +18,13 @@ package org.terasology.core.world.generator.worldGenerators;
 import org.terasology.core.world.generator.facetProviders.BiomeProvider;
 import org.terasology.core.world.generator.facetProviders.DefaultFloraProvider;
 import org.terasology.core.world.generator.facetProviders.DefaultTreeProvider;
-import org.terasology.core.world.generator.facetProviders.PlateauProvider;
 import org.terasology.core.world.generator.facetProviders.PerlinBaseSurfaceProvider;
 import org.terasology.core.world.generator.facetProviders.PerlinHillsAndMountainsProvider;
 import org.terasology.core.world.generator.facetProviders.PerlinHumidityProvider;
 import org.terasology.core.world.generator.facetProviders.PerlinOceanProvider;
 import org.terasology.core.world.generator.facetProviders.PerlinRiverProvider;
 import org.terasology.core.world.generator.facetProviders.PerlinSurfaceTemperatureProvider;
+import org.terasology.core.world.generator.facetProviders.PlateauProvider;
 import org.terasology.core.world.generator.facetProviders.SeaLevelProvider;
 import org.terasology.core.world.generator.facetProviders.SurfaceToDensityProvider;
 import org.terasology.core.world.generator.rasterizers.FloraRasterizer;
@@ -38,7 +38,6 @@ import org.terasology.math.geom.ImmutableVector2i;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.registry.In;
 import org.terasology.world.generation.BaseFacetedWorldGenerator;
-import org.terasology.world.generation.SurfaceHeightCompatibilityProvider;
 import org.terasology.world.generation.WorldBuilder;
 import org.terasology.world.generator.RegisterWorldGenerator;
 import org.terasology.world.generator.plugin.WorldGeneratorPluginLibrary;
@@ -81,7 +80,6 @@ public class PerlinFacetedWorldGenerator extends BaseFacetedWorldGenerator {
                 .addProvider(new DefaultFloraProvider())
                 .addProvider(new DefaultTreeProvider())
                 .addProvider(new PlateauProvider(spawnPos, seaLevel + 4, 10, 30))
-                .addProvider(new SurfaceHeightCompatibilityProvider())
                 .addRasterizer(new SolidRasterizer())
                 .addPlugins()
                 .addRasterizer(new FloraRasterizer())

--- a/src/main/java/org/terasology/core/world/generator/worldGenerators/SimplexFacetedWorldGenerator.java
+++ b/src/main/java/org/terasology/core/world/generator/worldGenerators/SimplexFacetedWorldGenerator.java
@@ -19,13 +19,13 @@ import org.terasology.core.world.generator.facetProviders.BiomeProvider;
 import org.terasology.core.world.generator.facetProviders.DefaultFloraProvider;
 import org.terasology.core.world.generator.facetProviders.DefaultTreeProvider;
 import org.terasology.core.world.generator.facetProviders.PlateauProvider;
+import org.terasology.core.world.generator.facetProviders.SeaLevelProvider;
 import org.terasology.core.world.generator.facetProviders.SimplexBaseSurfaceProvider;
 import org.terasology.core.world.generator.facetProviders.SimplexHillsAndMountainsProvider;
 import org.terasology.core.world.generator.facetProviders.SimplexHumidityProvider;
 import org.terasology.core.world.generator.facetProviders.SimplexOceanProvider;
 import org.terasology.core.world.generator.facetProviders.SimplexRiverProvider;
 import org.terasology.core.world.generator.facetProviders.SimplexSurfaceTemperatureProvider;
-import org.terasology.core.world.generator.facetProviders.SeaLevelProvider;
 import org.terasology.core.world.generator.facetProviders.SurfaceToDensityProvider;
 import org.terasology.core.world.generator.rasterizers.FloraRasterizer;
 import org.terasology.core.world.generator.rasterizers.SolidRasterizer;
@@ -38,7 +38,6 @@ import org.terasology.math.geom.ImmutableVector2i;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.registry.In;
 import org.terasology.world.generation.BaseFacetedWorldGenerator;
-import org.terasology.world.generation.SurfaceHeightCompatibilityProvider;
 import org.terasology.world.generation.WorldBuilder;
 import org.terasology.world.generator.RegisterWorldGenerator;
 import org.terasology.world.generator.plugin.WorldGeneratorPluginLibrary;
@@ -81,7 +80,6 @@ public class SimplexFacetedWorldGenerator extends BaseFacetedWorldGenerator {
                 .addProvider(new DefaultFloraProvider())
                 .addProvider(new DefaultTreeProvider())
                 .addProvider(new PlateauProvider(spawnPos, seaLevel + 4, 10, 30))
-                .addProvider(new SurfaceHeightCompatibilityProvider())
                 .addRasterizer(new SolidRasterizer())
                 .addPlugins()
                 .addRasterizer(new FloraRasterizer())


### PR DESCRIPTION
Remove the remaining references to SurfaceHeightFacet that were left in for compatibility, in preparation for it getting deleted. This can be merged after the remaining PRs listed in https://github.com/MovingBlocks/Terasology/pull/4237 are merged.