### PR TITLE
feat(SpawnPlateauProvider): derive target height from elevation and sea level facets

### DIFF
--- a/src/main/java/org/terasology/core/world/generator/facetProviders/PlateauProvider.java
+++ b/src/main/java/org/terasology/core/world/generator/facetProviders/PlateauProvider.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2014 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.core.world.generator.facetProviders;
 
 import org.terasology.math.Region3i;
@@ -23,15 +10,18 @@ import org.terasology.math.geom.Rect2i;
 import org.terasology.world.generation.Facet;
 import org.terasology.world.generation.FacetProvider;
 import org.terasology.world.generation.GeneratingRegion;
+import org.terasology.world.generation.Requires;
 import org.terasology.world.generation.Updates;
 import org.terasology.world.generation.facets.ElevationFacet;
 
 import com.google.common.base.Preconditions;
+import org.terasology.world.generation.facets.SeaLevelFacet;
 
 
 /**
- * Flattens the surface in a circular area around a given coordinate.
- * The area outside this area will be adjusted up to a certain radius to generate a smooth embedding.
+ * Flattens the surface in a circular area around a given coordinate. The area outside this area will be adjusted up to
+ * a certain radius to generate a smooth embedding with the {@link ElevationFacet}. It is guaranteed that the plateau is
+ * above the sea level as defined by {@link SeaLevelFacet}.
  * <pre>
  *           inner rad.
  *           __________
@@ -41,25 +31,40 @@ import com.google.common.base.Preconditions;
  * </pre>
  */
 @Updates(@Facet(ElevationFacet.class))
+@Requires(@Facet(SeaLevelFacet.class))
 public class PlateauProvider implements FacetProvider {
 
     private final ImmutableVector2i centerPos;
-    private final float targetHeight;
     private final float innerRadius;
     private final float outerRadius;
 
     /**
      * @param center the center of the circle-shaped plateau
-     * @param targetHeight the height level of the plateau
      * @param innerRadius the radius of the flat plateau
      * @param outerRadius the radius of the affected (smoothened) area
      */
+    public PlateauProvider(BaseVector2i center, float innerRadius, float outerRadius) {
+        Preconditions.checkArgument(innerRadius >= 0, "innerRadius must be >= 0");
+        Preconditions.checkArgument(outerRadius > innerRadius, "outerRadius must be larger than innerRadius");
+
+        this.centerPos = ImmutableVector2i.createOrUse(center);
+        this.innerRadius = innerRadius;
+        this.outerRadius = outerRadius;
+    }
+
+    /**
+     * @param center the center of the circle-shaped plateau
+     * @param targetHeight ignored
+     * @param innerRadius the radius of the flat plateau
+     * @param outerRadius the radius of the affected (smoothened) area
+     * @deprecated the targetHeight is ignored, use {@link #PlateauProvider(BaseVector2i, float, float)} instead
+     */
+    @Deprecated
     public PlateauProvider(BaseVector2i center, float targetHeight, float innerRadius, float outerRadius) {
         Preconditions.checkArgument(innerRadius >= 0, "innerRadius must be >= 0");
         Preconditions.checkArgument(outerRadius > innerRadius, "outerRadius must be larger than innerRadius");
 
         this.centerPos = ImmutableVector2i.createOrUse(center);
-        this.targetHeight = targetHeight;
         this.innerRadius = innerRadius;
         this.outerRadius = outerRadius;
     }
@@ -71,6 +76,9 @@ public class PlateauProvider implements FacetProvider {
 
         if (rc.distanceSquared(centerPos.x(), centerPos.y()) <= outerRadius * outerRadius) {
             ElevationFacet facet = region.getRegionFacet(ElevationFacet.class);
+            SeaLevelFacet seaLevel = region.getRegionFacet(SeaLevelFacet.class);
+
+            float targetHeight = Math.max(facet.getWorld(centerPos), seaLevel.getSeaLevel() + 3);
 
             // update the surface height
             for (BaseVector2i pos : facet.getWorldRegion().contents()) {

--- a/src/main/java/org/terasology/core/world/generator/facetProviders/SpawnPlateauProvider.java
+++ b/src/main/java/org/terasology/core/world/generator/facetProviders/SpawnPlateauProvider.java
@@ -1,0 +1,77 @@
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+package org.terasology.core.world.generator.facetProviders;
+
+import org.terasology.math.Region3i;
+import org.terasology.math.TeraMath;
+import org.terasology.math.geom.BaseVector2i;
+import org.terasology.math.geom.ImmutableVector2i;
+import org.terasology.math.geom.Rect2i;
+import org.terasology.world.generation.Facet;
+import org.terasology.world.generation.FacetBorder;
+import org.terasology.world.generation.FacetProvider;
+import org.terasology.world.generation.GeneratingRegion;
+import org.terasology.world.generation.Requires;
+import org.terasology.world.generation.Updates;
+import org.terasology.world.generation.facets.ElevationFacet;
+import org.terasology.world.generation.facets.SeaLevelFacet;
+
+
+/**
+ * Flattens the surface in a circular area around a given coordinate.
+ * <p>
+ * The area outside this area will be adjusted up to a fixed radius of {@link SpawnPlateauProvider#OUTER_RADIUS} to
+ * generate a smooth embedding with the {@link ElevationFacet}. It is guaranteed that the plateau is above the sea level
+ * as defined by {@link SeaLevelFacet}.
+ * <pre>
+ *           inner rad.
+ *           __________
+ *          /          \
+ *         /            \
+ *    ~~~~~  outer rad.  ~~~~~
+ * </pre>
+ */
+@Requires(@Facet(SeaLevelFacet.class))
+@Updates(@Facet(value = ElevationFacet.class, border = @FacetBorder(sides = SpawnPlateauProvider.OUTER_RADIUS)))
+public class SpawnPlateauProvider implements FacetProvider {
+
+    public static final int OUTER_RADIUS = 16;
+    public static final int OUTER_RADIUS_SQUARED = OUTER_RADIUS * OUTER_RADIUS;
+    public static final int INNER_RADIUS = 4;
+
+    private final ImmutableVector2i centerPos;
+
+    /**
+     * @param center the center of the circle-shaped plateau
+     */
+    public SpawnPlateauProvider(BaseVector2i center) {
+        this.centerPos = ImmutableVector2i.createOrUse(center);
+    }
+
+    @Override
+    public void process(GeneratingRegion region) {
+        Region3i reg = region.getRegion();
+        Rect2i rc = Rect2i.createFromMinAndMax(reg.minX(), reg.minZ(), reg.maxX(), reg.maxZ());
+
+        if (rc.distanceSquared(centerPos.x(), centerPos.y()) <= OUTER_RADIUS_SQUARED) {
+            ElevationFacet facet = region.getRegionFacet(ElevationFacet.class);
+            SeaLevelFacet seaLevel = region.getRegionFacet(SeaLevelFacet.class);
+
+            float targetHeight = Math.max(facet.getWorld(centerPos), seaLevel.getSeaLevel() + 3);
+
+            // update the surface height
+            for (BaseVector2i pos : facet.getWorldRegion().contents()) {
+                float originalValue = facet.getWorld(pos);
+                int distSq = pos.distanceSquared(centerPos);
+
+                if (distSq <= INNER_RADIUS * INNER_RADIUS) {
+                    facet.setWorld(pos, targetHeight);
+                } else if (distSq <= OUTER_RADIUS_SQUARED) {
+                    double dist = pos.distance(centerPos) - INNER_RADIUS;
+                    float norm = (float) dist / (OUTER_RADIUS - INNER_RADIUS);
+                    facet.setWorld(pos, TeraMath.lerp(targetHeight, originalValue, norm));
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/terasology/core/world/generator/worldGenerators/PerlinFacetedWorldGenerator.java
+++ b/src/main/java/org/terasology/core/world/generator/worldGenerators/PerlinFacetedWorldGenerator.java
@@ -1,30 +1,17 @@
-/*
- * Copyright 2014 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.core.world.generator.worldGenerators;
 
 import org.terasology.core.world.generator.facetProviders.BiomeProvider;
 import org.terasology.core.world.generator.facetProviders.DefaultFloraProvider;
 import org.terasology.core.world.generator.facetProviders.DefaultTreeProvider;
-import org.terasology.core.world.generator.facetProviders.PlateauProvider;
 import org.terasology.core.world.generator.facetProviders.PerlinBaseSurfaceProvider;
 import org.terasology.core.world.generator.facetProviders.PerlinHillsAndMountainsProvider;
 import org.terasology.core.world.generator.facetProviders.PerlinHumidityProvider;
 import org.terasology.core.world.generator.facetProviders.PerlinOceanProvider;
 import org.terasology.core.world.generator.facetProviders.PerlinRiverProvider;
 import org.terasology.core.world.generator.facetProviders.PerlinSurfaceTemperatureProvider;
+import org.terasology.core.world.generator.facetProviders.PlateauProvider;
 import org.terasology.core.world.generator.facetProviders.SeaLevelProvider;
 import org.terasology.core.world.generator.facetProviders.SurfaceToDensityProvider;
 import org.terasology.core.world.generator.rasterizers.FloraRasterizer;
@@ -44,11 +31,14 @@ import org.terasology.world.generator.RegisterWorldGenerator;
 import org.terasology.world.generator.plugin.WorldGeneratorPluginLibrary;
 
 /**
+ *
  */
-@RegisterWorldGenerator(id = "facetedperlin", displayName = "Perlin", description = "Faceted world generator using perlin")
+@RegisterWorldGenerator(id = "facetedperlin", displayName = "Perlin", description = "Faceted world generator using " +
+        "perlin")
 public class PerlinFacetedWorldGenerator extends BaseFacetedWorldGenerator {
 
-    private final FixedSpawner spawner = new FixedSpawner(0, 0);
+    private static final ImmutableVector2i SPAWN_POS = new ImmutableVector2i(0, 0);
+    private final FixedSpawner spawner = new FixedSpawner(SPAWN_POS.x(), SPAWN_POS.y());
 
     @In
     private WorldGeneratorPluginLibrary worldGeneratorPluginLibrary;
@@ -65,7 +55,6 @@ public class PerlinFacetedWorldGenerator extends BaseFacetedWorldGenerator {
     @Override
     protected WorldBuilder createWorld() {
         int seaLevel = 32;
-        ImmutableVector2i spawnPos = new ImmutableVector2i(0, 0); // as used by the spawner
 
         return new WorldBuilder(worldGeneratorPluginLibrary)
                 .setSeaLevel(seaLevel)
@@ -80,7 +69,7 @@ public class PerlinFacetedWorldGenerator extends BaseFacetedWorldGenerator {
                 .addProvider(new SurfaceToDensityProvider())
                 .addProvider(new DefaultFloraProvider())
                 .addProvider(new DefaultTreeProvider())
-                .addProvider(new PlateauProvider(spawnPos, 10, 30))
+                .addProvider(new PlateauProvider(SPAWN_POS, 4, 10))
                 .addProvider(new SurfaceHeightCompatibilityProvider())
                 .addRasterizer(new SolidRasterizer())
                 .addPlugins()

--- a/src/main/java/org/terasology/core/world/generator/worldGenerators/PerlinFacetedWorldGenerator.java
+++ b/src/main/java/org/terasology/core/world/generator/worldGenerators/PerlinFacetedWorldGenerator.java
@@ -11,8 +11,8 @@ import org.terasology.core.world.generator.facetProviders.PerlinHumidityProvider
 import org.terasology.core.world.generator.facetProviders.PerlinOceanProvider;
 import org.terasology.core.world.generator.facetProviders.PerlinRiverProvider;
 import org.terasology.core.world.generator.facetProviders.PerlinSurfaceTemperatureProvider;
-import org.terasology.core.world.generator.facetProviders.PlateauProvider;
 import org.terasology.core.world.generator.facetProviders.SeaLevelProvider;
+import org.terasology.core.world.generator.facetProviders.SpawnPlateauProvider;
 import org.terasology.core.world.generator.facetProviders.SurfaceToDensityProvider;
 import org.terasology.core.world.generator.rasterizers.FloraRasterizer;
 import org.terasology.core.world.generator.rasterizers.SolidRasterizer;
@@ -69,7 +69,7 @@ public class PerlinFacetedWorldGenerator extends BaseFacetedWorldGenerator {
                 .addProvider(new SurfaceToDensityProvider())
                 .addProvider(new DefaultFloraProvider())
                 .addProvider(new DefaultTreeProvider())
-                .addProvider(new PlateauProvider(SPAWN_POS, 4, 10))
+                .addProvider(new SpawnPlateauProvider(SPAWN_POS))
                 .addProvider(new SurfaceHeightCompatibilityProvider())
                 .addRasterizer(new SolidRasterizer())
                 .addPlugins()

--- a/src/main/java/org/terasology/core/world/generator/worldGenerators/PerlinFacetedWorldGenerator.java
+++ b/src/main/java/org/terasology/core/world/generator/worldGenerators/PerlinFacetedWorldGenerator.java
@@ -80,7 +80,7 @@ public class PerlinFacetedWorldGenerator extends BaseFacetedWorldGenerator {
                 .addProvider(new SurfaceToDensityProvider())
                 .addProvider(new DefaultFloraProvider())
                 .addProvider(new DefaultTreeProvider())
-                .addProvider(new PlateauProvider(spawnPos, seaLevel + 4, 10, 30))
+                .addProvider(new PlateauProvider(spawnPos, 10, 30))
                 .addProvider(new SurfaceHeightCompatibilityProvider())
                 .addRasterizer(new SolidRasterizer())
                 .addPlugins()

--- a/src/main/java/org/terasology/core/world/generator/worldGenerators/SimplexFacetedWorldGenerator.java
+++ b/src/main/java/org/terasology/core/world/generator/worldGenerators/SimplexFacetedWorldGenerator.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2014 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.core.world.generator.worldGenerators;
 
 import org.terasology.core.world.generator.facetProviders.BiomeProvider;
@@ -48,7 +35,9 @@ import org.terasology.world.generator.plugin.WorldGeneratorPluginLibrary;
 @RegisterWorldGenerator(id = "facetedsimplex", displayName = "Simplex", description = "Experimental world generator based on Simplex noise")
 public class SimplexFacetedWorldGenerator extends BaseFacetedWorldGenerator {
 
-    private final FixedSpawner spawner = new FixedSpawner(0, 0);
+    private static final ImmutableVector2i SPAWN_POS = new ImmutableVector2i(0,0);
+
+    private final FixedSpawner spawner = new FixedSpawner(SPAWN_POS.x(), SPAWN_POS.y());
 
     @In
     private WorldGeneratorPluginLibrary worldGeneratorPluginLibrary;
@@ -65,7 +54,6 @@ public class SimplexFacetedWorldGenerator extends BaseFacetedWorldGenerator {
     @Override
     protected WorldBuilder createWorld() {
         int seaLevel = 32;
-        ImmutableVector2i spawnPos = new ImmutableVector2i(0, 0); // as used by the spawner
 
         return new WorldBuilder(worldGeneratorPluginLibrary)
                 .setSeaLevel(seaLevel)
@@ -80,7 +68,7 @@ public class SimplexFacetedWorldGenerator extends BaseFacetedWorldGenerator {
                 .addProvider(new SurfaceToDensityProvider())
                 .addProvider(new DefaultFloraProvider())
                 .addProvider(new DefaultTreeProvider())
-                .addProvider(new PlateauProvider(spawnPos, 10, 30))
+                .addProvider(new PlateauProvider(SPAWN_POS, 4, 10))
                 .addProvider(new SurfaceHeightCompatibilityProvider())
                 .addRasterizer(new SolidRasterizer())
                 .addPlugins()

--- a/src/main/java/org/terasology/core/world/generator/worldGenerators/SimplexFacetedWorldGenerator.java
+++ b/src/main/java/org/terasology/core/world/generator/worldGenerators/SimplexFacetedWorldGenerator.java
@@ -80,7 +80,7 @@ public class SimplexFacetedWorldGenerator extends BaseFacetedWorldGenerator {
                 .addProvider(new SurfaceToDensityProvider())
                 .addProvider(new DefaultFloraProvider())
                 .addProvider(new DefaultTreeProvider())
-                .addProvider(new PlateauProvider(spawnPos, seaLevel + 4, 10, 30))
+                .addProvider(new PlateauProvider(spawnPos, 10, 30))
                 .addProvider(new SurfaceHeightCompatibilityProvider())
                 .addRasterizer(new SolidRasterizer())
                 .addPlugins()

--- a/src/main/java/org/terasology/core/world/generator/worldGenerators/SimplexFacetedWorldGenerator.java
+++ b/src/main/java/org/terasology/core/world/generator/worldGenerators/SimplexFacetedWorldGenerator.java
@@ -13,6 +13,7 @@ import org.terasology.core.world.generator.facetProviders.SimplexOceanProvider;
 import org.terasology.core.world.generator.facetProviders.SimplexRiverProvider;
 import org.terasology.core.world.generator.facetProviders.SimplexSurfaceTemperatureProvider;
 import org.terasology.core.world.generator.facetProviders.SeaLevelProvider;
+import org.terasology.core.world.generator.facetProviders.SpawnPlateauProvider;
 import org.terasology.core.world.generator.facetProviders.SurfaceToDensityProvider;
 import org.terasology.core.world.generator.rasterizers.FloraRasterizer;
 import org.terasology.core.world.generator.rasterizers.SolidRasterizer;
@@ -68,7 +69,7 @@ public class SimplexFacetedWorldGenerator extends BaseFacetedWorldGenerator {
                 .addProvider(new SurfaceToDensityProvider())
                 .addProvider(new DefaultFloraProvider())
                 .addProvider(new DefaultTreeProvider())
-                .addProvider(new PlateauProvider(SPAWN_POS, 4, 10))
+                .addProvider(new SpawnPlateauProvider(SPAWN_POS))
                 .addProvider(new SurfaceHeightCompatibilityProvider())
                 .addRasterizer(new SolidRasterizer())
                 .addPlugins()


### PR DESCRIPTION
With this PR we derive the `targetHeight` of the spawn plateau from the `ElevationFacet` and `SeaLevelFacet` instead of using a fixed value. Might still look funny in some occasions, but the huge craters are gone.

Seed `iXpHtY7fk97YP9VI` would spawn in the water if the sea level would not be considered. 💧 

Seed `WtR9q4zA6yizPN5G` is just a pretty nice spawn point 🙃 