### PR TITLE
fix: Change biome selection so that snow biomes are actually possible.

### DIFF
--- a/src/main/java/org/terasology/core/world/generator/facetProviders/BiomeProvider.java
+++ b/src/main/java/org/terasology/core/world/generator/facetProviders/BiomeProvider.java
@@ -69,7 +69,7 @@ public class BiomeProvider implements FacetProvider {
                 biomeFacet.set(pos, CoreBiome.DESERT);
             } else if (hum >= 0.3f && hum <= 0.6f && temp >= 0.5f) {
                 biomeFacet.set(pos, CoreBiome.PLAINS);
-            } else if (temp <= 0.3f && hum > 0.5f) {
+            } else if (temp <= 0.3f) {
                 biomeFacet.set(pos, CoreBiome.SNOW);
             } else if (hum >= 0.2f && hum <= 0.6f && temp < 0.5f) {
                 biomeFacet.set(pos, CoreBiome.MOUNTAINS);


### PR DESCRIPTION
Don't require high absolute humidity (which can't coincide with low temperature) for snow biomes. Ice on the water still can't occur, because the ocean biome takes priority over the snow biome, but if this and https://github.com/Terasology/CoreWorlds/pull/18 are combined, small amounts of ice near the shore will be possible.