### PR TITLE
feat: Update CoreBiome and SolidRasterizer to use new Biome API for querying block types

### DIFF
--- a/src/main/java/org/terasology/core/world/CoreBiome.java
+++ b/src/main/java/org/terasology/core/world/CoreBiome.java
@@ -15,7 +15,11 @@
  */
 package org.terasology.core.world;
 
+import org.joml.Vector3ic;
 import org.terasology.biomesAPI.Biome;
+import org.terasology.engine.registry.CoreRegistry;
+import org.terasology.engine.world.block.Block;
+import org.terasology.engine.world.block.BlockManager;
 import org.terasology.naming.Name;
 
 public enum CoreBiome implements Biome {
@@ -30,9 +34,77 @@ public enum CoreBiome implements Biome {
     private final Name id;
     private final String displayName;
 
+    private Block stone;
+    private Block sand;
+    private Block grass;
+    private Block snow;
+    private Block dirt;
+
     CoreBiome(String displayName) {
         this.id = new Name("CoreWorlds:" + name());
         this.displayName = displayName;
+
+        BlockManager blockManager = CoreRegistry.get(BlockManager.class);
+        stone = blockManager.getBlock("CoreAssets:stone");
+        sand = blockManager.getBlock("CoreAssets:Sand");
+        grass = blockManager.getBlock("CoreAssets:Grass");
+        snow = blockManager.getBlock("CoreAssets:Snow");
+        dirt = blockManager.getBlock("CoreAssets:Dirt");
+    }
+
+    @Override
+    public Block getSurfaceBlock(Vector3ic pos, int seaLevel) {
+        int height = pos.y() - seaLevel;
+        switch (this) {
+            case FOREST:
+            case PLAINS:
+            case MOUNTAINS:
+                if (height > 96) {
+                    return snow;
+                } else if (height >= 0) {
+                    return grass;
+                } else {
+                    return dirt;
+                }
+            case SNOW:
+                if (height >= 0) {
+                    return snow;
+                } else {
+                    return dirt;
+                }
+            case DESERT:
+            case OCEAN:
+            case BEACH:
+                return sand;
+            default:
+                return dirt;
+        }
+    }
+
+    @Override
+    public Block getBelowSurfaceBlock(Vector3ic pos, float density) {
+        switch (this) {
+            case DESERT:
+                if (density > 8) {
+                    return stone;
+                } else {
+                    return sand;
+                }
+            case BEACH:
+                if (density > 2) {
+                    return stone;
+                } else {
+                    return sand;
+                }
+            case OCEAN:
+                return stone;
+            default:
+                if (density > 32) {
+                    return stone;
+                } else {
+                    return dirt;
+                }
+        }
     }
 
     @Override

--- a/src/main/java/org/terasology/core/world/generator/rasterizers/SolidRasterizer.java
+++ b/src/main/java/org/terasology/core/world/generator/rasterizers/SolidRasterizer.java
@@ -45,24 +45,14 @@ public class SolidRasterizer implements ScalableWorldRasterizer {
 
     private Block water;
     private Block ice;
-    private Block stone;
-    private Block sand;
-    private Block grass;
-    private Block snow;
-    private Block dirt;
     private BiomeRegistry biomeRegistry;
 
     @Override
     public void initialize() {
         BlockManager blockManager = CoreRegistry.get(BlockManager.class);
         biomeRegistry = CoreRegistry.get(BiomeRegistry.class);
-        stone = blockManager.getBlock("CoreAssets:Stone");
         water = blockManager.getBlock("CoreAssets:Water");
         ice = blockManager.getBlock("CoreAssets:Ice");
-        sand = blockManager.getBlock("CoreAssets:Sand");
-        grass = blockManager.getBlock("CoreAssets:Grass");
-        snow = blockManager.getBlock("CoreAssets:Snow");
-        dirt = blockManager.getBlock("CoreAssets:Dirt");
     }
 
     @Override

--- a/src/main/java/org/terasology/core/world/generator/rasterizers/SolidRasterizer.java
+++ b/src/main/java/org/terasology/core/world/generator/rasterizers/SolidRasterizer.java
@@ -93,9 +93,9 @@ public class SolidRasterizer implements ScalableWorldRasterizer {
                 // ensure that the ocean is at least 1 block thick.
                 chunk.setBlock(pos, water);
             } else if (density > 0 && surfacesFacet.get(pos)) {
-                chunk.setBlock(pos, getSurfaceBlock(biome, posY - seaLevel));
+                chunk.setBlock(pos, biome.getSurfaceBlock(pos, seaLevel));
             } else if (density > 0) {
-                chunk.setBlock(pos, getBelowSurfaceBlock(density, biome));
+                chunk.setBlock(pos, biome.getBelowSurfaceBlock(pos, density));
             } else if (posY <= seaLevel) {         // either OCEAN or SNOW
                 if (posY + scale > seaLevel && CoreBiome.SNOW == biome) {
                     chunk.setBlock(pos, ice);
@@ -103,60 +103,6 @@ public class SolidRasterizer implements ScalableWorldRasterizer {
                     chunk.setBlock(pos, water);
                 }
             }
-        }
-    }
-
-    private Block getSurfaceBlock(Biome type, float heightAboveSea) {
-        if (type instanceof CoreBiome) {
-            switch ((CoreBiome) type) {
-                case FOREST:
-                case PLAINS:
-                case MOUNTAINS:
-                    if (heightAboveSea > 96) {
-                        return snow;
-                    } else if (heightAboveSea >= 0) {
-                        return grass;
-                    } else {
-                        return dirt;
-                    }
-                case SNOW:
-                    if (heightAboveSea >= 0) {
-                        return snow;
-                    } else {
-                        return dirt;
-                    }
-                case DESERT:
-                case OCEAN:
-                case BEACH:
-                    return sand;
-            }
-        }
-        return dirt;
-    }
-
-    private Block getBelowSurfaceBlock(float density, Biome type) {
-        if (type instanceof CoreBiome) {
-            switch ((CoreBiome) type) {
-                case DESERT:
-                    if (density > 8) {
-                        return stone;
-                    } else {
-                        return sand;
-                    }
-                case BEACH:
-                    if (density > 2) {
-                        return stone;
-                    } else {
-                        return sand;
-                    }
-                case OCEAN:
-                    return stone;
-            }
-        }
-        if (density > 32) {
-            return stone;
-        } else {
-            return dirt;
         }
     }
 }


### PR DESCRIPTION
Now that https://github.com/Terasology/BiomesAPI/pull/12 is merged, the new API can be used for `CoreBiome`s. This doesn't change the generated terrain at all, just moves per-biome code from `SolidRasterizer` to `CoreBiome`.

I'm not sure how the dependency should be changed - should I change the minimum version of BiomesAPI to 4.1.1-SNAPSHOT? The version number hasn't changed since the API change, so it's possible to have BiomesAPI with that version number but without the new API, but maybe that's fine since it's a snapshot version.