### PR TITLE
fix: pass world position to biome methods

### DIFF
--- a/src/main/java/org/terasology/core/world/generator/rasterizers/SolidRasterizer.java
+++ b/src/main/java/org/terasology/core/world/generator/rasterizers/SolidRasterizer.java
@@ -16,6 +16,7 @@
 package org.terasology.core.world.generator.rasterizers;
 
 import org.joml.Vector2i;
+import org.joml.Vector3i;
 import org.joml.Vector3ic;
 import org.terasology.biomesAPI.Biome;
 import org.terasology.biomesAPI.BiomeRegistry;
@@ -65,11 +66,13 @@ public class SolidRasterizer implements ScalableWorldRasterizer {
         int seaLevel = seaLevelFacet.getSeaLevel();
 
         Vector2i pos2d = new Vector2i();
+        Vector3i worldPos = new Vector3i();
         for (Vector3ic pos : Chunks.CHUNK_REGION) {
             pos2d.set(pos.x(), pos.z());
             float density = solidityFacet.get(pos);
             float basePosY = (pos.y() + chunk.getChunkWorldOffsetY()) * scale;
             float posY = basePosY + Math.max(0, Math.min(scale, density));
+            chunk.chunkToWorldPosition(pos,  worldPos);
 
             // Check for an optional depth for this layer - if defined stop generating below that level
             if (surfaceDepthFacet != null && posY < surfaceDepthFacet.get(pos2d)) {
@@ -83,9 +86,9 @@ public class SolidRasterizer implements ScalableWorldRasterizer {
                 // ensure that the ocean is at least 1 block thick.
                 chunk.setBlock(pos, water);
             } else if (density > 0 && surfacesFacet.get(pos)) {
-                chunk.setBlock(pos, biome.getSurfaceBlock(pos, seaLevel));
+                chunk.setBlock(pos, biome.getSurfaceBlock(worldPos, seaLevel));
             } else if (density > 0) {
-                chunk.setBlock(pos, biome.getBelowSurfaceBlock(pos, density));
+                chunk.setBlock(pos, biome.getBelowSurfaceBlock(worldPos, density));
             } else if (posY <= seaLevel) {         // either OCEAN or SNOW
                 if (posY + scale > seaLevel && CoreBiome.SNOW == biome) {
                     chunk.setBlock(pos, ice);


### PR DESCRIPTION
In https://github.com/Terasology/CoreWorlds/pull/35, I forgot to convert the position to world coordinates before passing it to chunk methods. The only thing that affects right now is that mountain biomes don't have snow at high altitudes, but it also means that new biomes using the API will be rasterized incorrectly. This PR just converts to world coordinates before passing the position to the biome methods.