### PR TITLE
fix: move block caching to Biome.initialize

### DIFF
--- a/src/main/java/org/terasology/core/world/CoreBiome.java
+++ b/src/main/java/org/terasology/core/world/CoreBiome.java
@@ -43,7 +43,10 @@ public enum CoreBiome implements Biome {
     CoreBiome(String displayName) {
         this.id = new Name("CoreWorlds:" + name());
         this.displayName = displayName;
+    }
 
+    @Override
+    public void initialize() {
         BlockManager blockManager = CoreRegistry.get(BlockManager.class);
         stone = blockManager.getBlock("CoreAssets:stone");
         sand = blockManager.getBlock("CoreAssets:Sand");


### PR DESCRIPTION
Because the BlockManager isn't used until after systems are registered, this should fix the world setup and preview screens for CoreGameplay (https://github.com/MovingBlocks/Terasology/issues/4801). Depends on https://github.com/Terasology/BiomesAPI/pull/16.