### PR TITLE
fix: circular dependency with new facet update priority

### DIFF
--- a/src/main/java/org/terasology/core/world/generator/facetProviders/SpawnPlateauProvider.java
+++ b/src/main/java/org/terasology/core/world/generator/facetProviders/SpawnPlateauProvider.java
@@ -5,6 +5,7 @@ package org.terasology.core.world.generator.facetProviders;
 import org.joml.Vector2i;
 import org.joml.Vector2ic;
 import org.terasology.core.world.generator.facets.SurfaceRoughnessFacet;
+import org.terasology.engine.world.generation.UpdatePriority;
 import org.terasology.math.TeraMath;
 import org.terasology.joml.geom.Rectanglei;
 import org.terasology.engine.world.block.BlockRegion;
@@ -33,10 +34,10 @@ import org.terasology.engine.world.generation.facets.SeaLevelFacet;
  * </pre>
  */
 @Requires(@Facet(SeaLevelFacet.class))
-@Updates({
+@Updates(value = {
     @Facet(value = ElevationFacet.class, border = @FacetBorder(sides = SpawnPlateauProvider.OUTER_RADIUS)),
     @Facet(SurfaceRoughnessFacet.class)
-})
+}, priority = UpdatePriority.PRIORITY_REQUIRES - 10)
 public class SpawnPlateauProvider implements FacetProvider {
 
     public static final int OUTER_RADIUS = 16;


### PR DESCRIPTION
This fixes the circular dependency which is recognized by https://github.com/MovingBlocks/Terasology/pull/4833, which is the only change needed to make it work again. However, eventually it'd probably be a good idea to add explicit priorities to other CoreWorlds facet providers to make it more deterministic.