### PR TITLE
refactor: component field visibility public

### DIFF
--- a/src/main/java/org/terasology/core/world/generator/facetProviders/HeightMapSurfaceHeightProvider.java
+++ b/src/main/java/org/terasology/core/world/generator/facetProviders/HeightMapSurfaceHeightProvider.java
@@ -151,22 +151,22 @@ public class HeightMapSurfaceHeightProvider implements ConfigurableFacetProvider
         }
     }
 
-    private static class HeightMapConfiguration implements Component<HeightMapConfiguration> {
+    public static class HeightMapConfiguration implements Component<HeightMapConfiguration> {
 
         @Enum(description = "Wrap Mode")
-        private WrapMode wrapMode = WrapMode.REPEAT;
+        public WrapMode wrapMode = WrapMode.REPEAT;
 
         @List(items = { "platec_heightmap", "opposing_islands" }, description = "Height Map")
-        private String heightMap = "platec_heightmap";
+        public String heightMap = "platec_heightmap";
 
         @Range(min = 0, max = 50f, increment = 1f, precision = 0, description = "Height Offset")
-        private float heightOffset = 12;
+        public float heightOffset = 12;
 
         @Range(min = 10, max = 200f, increment = 1f, precision = 0, description = "Height Scale Factor")
-        private float heightScale = 70;
+        public float heightScale = 70;
 
         @Range(min = 1, max = 32, increment = 1, precision = 0, description = "Terrain Scale Factor")
-        private int terrainScale = 8;
+        public int terrainScale = 8;
 
         @Override
         public void copyFrom(HeightMapConfiguration other) {

--- a/src/main/java/org/terasology/core/world/generator/facetProviders/SimplexRiverProvider.java
+++ b/src/main/java/org/terasology/core/world/generator/facetProviders/SimplexRiverProvider.java
@@ -60,7 +60,7 @@ public class SimplexRiverProvider implements ScalableFacetProvider, Configurable
         this.configuration = (SimplexRiverProviderConfiguration) configuration;
     }
 
-    private static class SimplexRiverProviderConfiguration implements Component<SimplexRiverProviderConfiguration> {
+    public static class SimplexRiverProviderConfiguration implements Component<SimplexRiverProviderConfiguration> {
         @Range(min = 0, max = 64f, increment = 1f, precision = 0, description = "River Depth")
         public float maxDepth = 16;
 


### PR DESCRIPTION
Newer Java versions are stricter with regards to access restrictions when using reflection.
This affects in particular the serialization of non-public fields in our component classes.
For this reason, we decided to exclude non-public component fields from serialization and refactor all non-public component fields to be public instead to ensure not breaking any game and especially saving/loading behavior.

A future module overhaul may have a more detailed look into the components and make considerate decisions to use non-public fields.

Relates to https://github.com/MovingBlocks/Terasology/pull/5191